### PR TITLE
force `webDialog()` calls to run on the main thread

### DIFF
--- a/SDJSBridge/JavaScript API/Platform API/SDJSPlatformScript.m
+++ b/SDJSBridge/JavaScript API/Platform API/SDJSPlatformScript.m
@@ -123,7 +123,11 @@ static NSUInteger const kSDJSPlatformScriptVersionNumber = 1;
 }
 
 - (void)showWebDialogWithOptions:(NSDictionary *)options callback:(JSValue *)callback {
-    [self.webDialogScript showWebDialogWithOptions:options callback:[SDJSPlatformScript handlerOutputBlockWithCallback:callback]];
+    // run on main thread because the result of this call allocs a web view
+    // instance which is not thread safe
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.webDialogScript showWebDialogWithOptions:options callback:[SDJSPlatformScript handlerOutputBlockWithCallback:callback]];
+    });
 }
 
 #pragma mark - Radio Dialog


### PR DESCRIPTION
The webDialog() bridge method allocs a new web view to be used as a
modal view and the extensions made to web view in SDJSExtensions forces
the web view alloc to happen on the main thread. Because of this we
need to make sure this method is always run on the main thread.