### PR TITLE
prefix progress delegate method names under 'progressScript' to follow convention

### DIFF
--- a/SDJSBridge/JavaScript API/Platform API/SDJSProgressHUDScript.h
+++ b/SDJSBridge/JavaScript API/Platform API/SDJSProgressHUDScript.h
@@ -20,12 +20,12 @@
  Show the progress HUD
  @param message Message text to display in the progerss HUD.
  */
-- (void)showProgressHUDWithMessage:(NSString *)message;
+- (void)progressScriptShowProgressHUDWithMessage:(NSString *)message;
 
 /**
  Hide the progress HUD
  */
-- (void)hideProgressHUD;
+- (void)progressScriptHideProgressHUD;
 
 @end
 

--- a/SDJSBridge/JavaScript API/Platform API/SDJSProgressHUDScript.m
+++ b/SDJSBridge/JavaScript API/Platform API/SDJSProgressHUDScript.m
@@ -16,16 +16,16 @@ NSString * const SDJSProgressOptionMessageKey = @"message";
 - (void)showWithMessage:(NSString *)message {
     @strongify(self.delegate, strongDelegate);
     
-    if ([strongDelegate respondsToSelector:@selector(showProgressHUDWithMessage:)]) {
-        [strongDelegate showProgressHUDWithMessage:message];
+    if ([strongDelegate respondsToSelector:@selector(progressScriptShowProgressHUDWithMessage:)]) {
+        [strongDelegate progressScriptShowProgressHUDWithMessage:message];
     }
 }
 
 - (void)hide {
     @strongify(self.delegate, strongDelegate);
     
-    if ([strongDelegate respondsToSelector:@selector(hideProgressHUD)]) {
-        [strongDelegate hideProgressHUD];
+    if ([strongDelegate respondsToSelector:@selector(progressScriptHideProgressHUD)]) {
+        [strongDelegate progressScriptHideProgressHUD];
     }
 }
 


### PR DESCRIPTION
better to prefix these like the other script delegate methods so they don't clash with any of the delegate object's methods